### PR TITLE
Fix #4 (fix rewrite of 'cataloginventory/stock_item' model)

### DIFF
--- a/step1/app/code/community/Profileolabs/Shoppingflux/Model/Export/Rewrite/CatalogInventory/Stock/Item.php
+++ b/step1/app/code/community/Profileolabs/Shoppingflux/Model/Export/Rewrite/CatalogInventory/Stock/Item.php
@@ -8,7 +8,7 @@
  */
 
 
-if(file_exists(BP.'/app/code/community/MDN/AdvancedStock/Model/CatalogInventory/Stock/Item.php') || file_exists(BP.'/app/code/local/MDN/AdvancedStock/Model/CatalogInventory/Stock/Item.php')) {
+if (Mage::helper('core')->isModuleEnabled('MDN_AdvancedStock') && class_exists('MDN_AdvancedStock_Model_CatalogInventory_Stock_Item')) {
     class Profileolabs_Shoppingflux_Model_Export_Rewrite_CatalogInventory_Stock_Item_Compatibility extends MDN_AdvancedStock_Model_CatalogInventory_Stock_Item {}
 } else {
     class Profileolabs_Shoppingflux_Model_Export_Rewrite_CatalogInventory_Stock_Item_Compatibility extends Mage_CatalogInventory_Model_Stock_Item {}


### PR DESCRIPTION
If the MDN_AdvancedStock module has been uploaded but is not enabled, no rewrite should be based on its classes